### PR TITLE
file submission was failing on reading file

### DIFF
--- a/src/victims_web/handlers/security.py
+++ b/src/victims_web/handlers/security.py
@@ -146,7 +146,7 @@ def validate_signature():
 
         if len(request.files) > 0:
             for f in request.files.values():
-                md5sums.append(md5(f.stream.getvalue()).hexdigest())
+                md5sums.append(md5(f.read()).hexdigest())
 
         expected = generate_signature(
             apikey, request.method, path,


### PR DESCRIPTION
While testing file submission locally I found that I needed to make this change for a File to be submitted to the server correctly. Otherwise an DEBUG message appears and auth fails:

DEBUG: 'file' object has no attribute 'getvalue'